### PR TITLE
Making library more compliant to work with VerneMQ

### DIFF
--- a/lib/src/messages/connect/mqtt_client_mqtt_connect_message.dart
+++ b/lib/src/messages/connect/mqtt_client_mqtt_connect_message.dart
@@ -74,12 +74,14 @@ class MqttConnectMessage extends MqttMessage {
 
   /// Sets the will message.
   MqttConnectMessage withWillMessage(String willMessage) {
+    will();
     this.payload.willMessage = willMessage;
     return this;
   }
 
   /// Sets the Will Topic
   MqttConnectMessage withWillTopic(String willTopic) {
+    will();
     this.payload.willTopic = willTopic;
     return this;
   }

--- a/lib/src/mqtt_client.dart
+++ b/lib/src/mqtt_client.dart
@@ -181,10 +181,10 @@ class MqttClient {
 
   /// Disconnect from the broker
   void disconnect() {
-    _connectionHandler.disconnect();
+    _connectionHandler ?? _connectionHandler.disconnect();
     _publishingManager = null;
     _subscriptionsManager = null;
-    _keepAlive.stop();
+    _keepAlive ?? _keepAlive.stop();
     _keepAlive = null;
     _connectionHandler = null;
   }

--- a/lib/src/mqtt_client.dart
+++ b/lib/src/mqtt_client.dart
@@ -181,10 +181,10 @@ class MqttClient {
 
   /// Disconnect from the broker
   void disconnect() {
-    _connectionHandler ?? _connectionHandler.disconnect();
+    _connectionHandler?.disconnect();
     _publishingManager = null;
     _subscriptionsManager = null;
-    _keepAlive ?? _keepAlive.stop();
+    _keepAlive?.stop();
     _keepAlive = null;
     _connectionHandler = null;
   }

--- a/lib/src/mqtt_client.dart
+++ b/lib/src/mqtt_client.dart
@@ -128,6 +128,9 @@ class MqttClient {
     if (connectionMessage == null) {
       connectionMessage = new MqttConnectMessage()
           .withClientIdentifier(clientIdentifier)
+           // willQos needed even if willFlag is false, MQTT-3.1.2-13:
+           // "If the Will Flag is set to 0, then the Will QoS MUST be set to 0 (0x00)."
+          .withWillQos(MqttQos.atMostOnce)
           .keepAliveFor(Constants.defaultKeepAlive)
           .authenticateAs(username, password)
           .startClean();


### PR DESCRIPTION
I chatted with one of the developers of VerneMQ and he helped me diagnose why I couldn't connect to VerneMQ (but worked fine with Mosquitto or EMQTT). It turns out one must send willQos even if willFlag is set to false. I also added some defensive tweaks, like if you forget to call will() (API not so great since easy to miss) and also making sure disconnect() does not fail.