### PR TITLE
Moved from List<int> to Uint8List due

### DIFF
--- a/lib/src/connectionhandling/mqtt_client_mqtt_ws2_connection.dart
+++ b/lib/src/connectionhandling/mqtt_client_mqtt_ws2_connection.dart
@@ -8,14 +8,14 @@
 
 part of mqtt_client;
 
-class _DetachedSocket extends Stream<List<int>> implements Socket {
+class _DetachedSocket extends Stream<Uint8List> implements Socket {
   _DetachedSocket(this._socket, this._subscription);
 
-  final StreamSubscription<List<int>> _subscription;
+  final StreamSubscription<Uint8List> _subscription;
   final Socket _socket;
 
   @override
-  StreamSubscription<List<int>> listen(void onData(List<int> event),
+  StreamSubscription<Uint8List> listen(void onData(Uint8List event),
       {Function onError, void onDone(), bool cancelOnError}) {
     _subscription
       ..onData(onData)


### PR DESCRIPTION
In the current flutter master (so latest Dart) the implementation of the Dart Socket changed from List<int> to Uint8List. This causes mqtt_client to fail because it overrides some methods in a class that extends Socket. I have moved the problematic methods to Uint8List. The exact error dart was throwing is: `The class '_DetachedSocket' cannot implement both 'Stream<List<int>>' and 'Stream<Uint8List>' because the type arguments are different. dart(conflicting_generic_interfaces)`