### PR TITLE
change update stream as property

### DIFF
--- a/lib/src/mqtt_client.dart
+++ b/lib/src/mqtt_client.dart
@@ -193,7 +193,12 @@ class MqttClient {
   events.EventBus clientEventBus;
 
   /// The stream on which all subscribed topic updates are published to
-  Stream<List<MqttReceivedMessage<MqttMessage>>> updates;
+  Stream<List<MqttReceivedMessage<MqttMessage>>> get updates {
+    if (null == subscriptionsManager) {
+      return null;
+    }
+    return subscriptionsManager.subscriptionNotifier.changes;
+  }
 
   /// Comon client connection method.
   Future<MqttClientConnectionStatus> connect(
@@ -221,7 +226,6 @@ class MqttClient {
     subscriptionsManager.onSubscribed = onSubscribed;
     subscriptionsManager.onUnsubscribed = onUnsubscribed;
     subscriptionsManager.onSubscribeFail = onSubscribeFail;
-    updates = subscriptionsManager.subscriptionNotifier.changes;
     keepAlive = MqttConnectionKeepAlive(connectionHandler, keepAlivePeriod);
     if (pongCallback != null) {
       keepAlive.pongCallback = pongCallback;


### PR DESCRIPTION
Because that the stream in subscriptionNotifier will drop after all subscription are finished and create a new one when the new subscription comes, the outside class(mqtt_client) variable:  `update` will not be sync-ed with `changes`.No listener will receive the new messages therefore.

In this pull request, I change the mqtt_client's updates variable to a property to make sure `update` is always synchronozied with `changes`