### PR TITLE
Only send disconnect message when connected

### DIFF
--- a/lib/src/connectionhandling/mqtt_client_mqtt_connection_handler_base.dart
+++ b/lib/src/connectionhandling/mqtt_client_mqtt_connection_handler_base.dart
@@ -193,8 +193,10 @@ abstract class MqttConnectionHandlerBase implements IMqttConnectionHandler {
   @override
   MqttConnectionState disconnect() {
     MqttLogger.log('SynchronousMqttServerConnectionHandler::disconnect');
-    // Send a disconnect message to the broker
-    sendMessage(MqttDisconnectMessage());
+    if (connectionStatus.state == MqttConnectionState.connected) {
+      // Send a disconnect message to the broker
+      sendMessage(MqttDisconnectMessage());
+    }
     // Disconnect
     _performConnectionDisconnect();
     return connectionStatus.state;


### PR DESCRIPTION
Currently the disconnect message is sent regardless of connection state, leading to errors like these: `DomException:<InvalidStateError: Failed to execute 'send' on 'WebSocket': Still in CONNECTING state.>`. This is because DOM WS can not send anything when the connection is not ready yet.