### PR TITLE
Customizable maxConnectionAttempts

### DIFF
--- a/lib/mqtt_browser_client.dart
+++ b/lib/mqtt_browser_client.dart
@@ -11,6 +11,7 @@ import 'dart:async';
 import 'dart:html';
 import 'dart:typed_data';
 import 'package:event_bus/event_bus.dart' as events;
+import 'package:meta/meta.dart';
 import 'package:typed_data/typed_data.dart' as typed;
 import 'mqtt_client.dart';
 

--- a/lib/mqtt_server_client.dart
+++ b/lib/mqtt_server_client.dart
@@ -13,6 +13,7 @@ import 'dart:io';
 import 'dart:typed_data';
 import 'package:crypto/crypto.dart';
 import 'package:event_bus/event_bus.dart' as events;
+import 'package:meta/meta.dart';
 import 'package:typed_data/typed_data.dart' as typed;
 import 'mqtt_client.dart';
 

--- a/lib/src/connectionhandling/browser/mqtt_client_mqtt_browser_connection_handler.dart
+++ b/lib/src/connectionhandling/browser/mqtt_client_mqtt_browser_connection_handler.dart
@@ -11,5 +11,6 @@ part of mqtt_browser_client;
 ///  for browser based connection handler implementations.
 abstract class MqttBrowserConnectionHandler extends MqttConnectionHandlerBase {
   /// Initializes a new instance of the [MqttBrowserConnectionHandler] class.
-  MqttBrowserConnectionHandler();
+  MqttBrowserConnectionHandler({@required int maxConnectionAttempts})
+      : super(maxConnectionAttempts: maxConnectionAttempts);
 }

--- a/lib/src/connectionhandling/browser/mqtt_client_synchronous_mqtt_browser_connection_handler.dart
+++ b/lib/src/connectionhandling/browser/mqtt_client_synchronous_mqtt_browser_connection_handler.dart
@@ -12,7 +12,10 @@ part of mqtt_browser_client;
 class SynchronousMqttBrowserConnectionHandler
     extends MqttBrowserConnectionHandler {
   /// Initializes a new instance of the MqttConnectionHandler class.
-  SynchronousMqttBrowserConnectionHandler(clientEventBus) {
+  SynchronousMqttBrowserConnectionHandler(
+    clientEventBus, {
+    @required int maxConnectionAttempts,
+  }) : super(maxConnectionAttempts: maxConnectionAttempts) {
     this.clientEventBus = clientEventBus;
     clientEventBus.on<AutoReconnect>().listen(autoReconnect);
     registerForMessage(MqttMessageType.connectAck, connectAckProcessor);
@@ -69,7 +72,7 @@ class SynchronousMqttBrowserConnectionHandler
           'SynchronousMqttBrowserConnectionHandler::internalConnect - '
           'post sleep, state = $connectionStatus');
     } while (connectionStatus.state != MqttConnectionState.connected &&
-        ++connectionAttempts < MqttConnectionHandlerBase.maxConnectionAttempts);
+        ++connectionAttempts < maxConnectionAttempts);
     // If we've failed to handshake with the broker, throw an exception.
     if (connectionStatus.state != MqttConnectionState.connected) {
       if (!autoReconnectInProgress) {
@@ -78,12 +81,12 @@ class SynchronousMqttBrowserConnectionHandler
         if (connectionStatus.returnCode ==
             MqttConnectReturnCode.noneSpecified) {
           throw NoConnectionException('The maximum allowed connection attempts '
-              '({$MqttConnectionHandlerBase.maxConnectionAttempts}) were exceeded. '
+              '({$maxConnectionAttempts}) were exceeded. '
               'The broker is not responding to the connection request message '
               '(Missing Connection Acknowledgement?');
         } else {
           throw NoConnectionException('The maximum allowed connection attempts '
-              '({$MqttConnectionHandlerBase.maxConnectionAttempts}) were exceeded. '
+              '({$maxConnectionAttempts}) were exceeded. '
               'The broker is not responding to the connection request message correctly'
               'The return code is ${connectionStatus.returnCode}');
         }

--- a/lib/src/connectionhandling/mqtt_client_mqtt_connection_handler_base.dart
+++ b/lib/src/connectionhandling/mqtt_client_mqtt_connection_handler_base.dart
@@ -11,7 +11,7 @@ part of mqtt_client;
 ///  to serverand browser connection handler implementations.
 abstract class MqttConnectionHandlerBase implements IMqttConnectionHandler {
   /// Initializes a new instance of the [MqttConnectionHandlerBase] class.
-  MqttConnectionHandlerBase();
+  MqttConnectionHandlerBase({@required this.maxConnectionAttempts});
 
   /// Successful connection callback.
   @override
@@ -46,7 +46,7 @@ abstract class MqttConnectionHandlerBase implements IMqttConnectionHandler {
   bool Function(dynamic certificate) onBadCertificate;
 
   /// Max connection attempts
-  static const int maxConnectionAttempts = 3;
+  final int maxConnectionAttempts;
 
   /// The broker connection acknowledgment timer
   @protected

--- a/lib/src/connectionhandling/server/mqtt_client_mqtt_server_connection_handler.dart
+++ b/lib/src/connectionhandling/server/mqtt_client_mqtt_server_connection_handler.dart
@@ -11,7 +11,8 @@ part of mqtt_server_client;
 ///  for server based connections.
 abstract class MqttServerConnectionHandler extends MqttConnectionHandlerBase {
   /// Initializes a new instance of the [MqttServerConnectionHandler] class.
-  MqttServerConnectionHandler();
+  MqttServerConnectionHandler({@required int maxConnectionAttempts})
+      : super(maxConnectionAttempts: maxConnectionAttempts);
 
   /// Use a websocket rather than TCP
   bool useWebSocket = false;

--- a/lib/src/connectionhandling/server/mqtt_client_synchronous_mqtt_server_connection_handler.dart
+++ b/lib/src/connectionhandling/server/mqtt_client_synchronous_mqtt_server_connection_handler.dart
@@ -12,7 +12,10 @@ part of mqtt_server_client;
 class SynchronousMqttServerConnectionHandler
     extends MqttServerConnectionHandler {
   /// Initializes a new instance of the SynchronousMqttConnectionHandler class.
-  SynchronousMqttServerConnectionHandler(var clientEventBus) {
+  SynchronousMqttServerConnectionHandler(
+    var clientEventBus, {
+    @required int maxConnectionAttempts,
+  }) : super(maxConnectionAttempts: maxConnectionAttempts) {
     this.clientEventBus = clientEventBus;
     clientEventBus.on<AutoReconnect>().listen(autoReconnect);
     registerForMessage(MqttMessageType.connectAck, connectAckProcessor);
@@ -92,7 +95,7 @@ class SynchronousMqttServerConnectionHandler
           'SynchronousMqttServerConnectionHandler::internalConnect - '
           'post sleep, state = $connectionStatus');
     } while (connectionStatus.state != MqttConnectionState.connected &&
-        ++connectionAttempts < MqttConnectionHandlerBase.maxConnectionAttempts);
+        ++connectionAttempts < maxConnectionAttempts);
     // If we've failed to handshake with the broker, throw an exception.
     if (connectionStatus.state != MqttConnectionState.connected) {
       if (!autoReconnectInProgress) {
@@ -101,12 +104,12 @@ class SynchronousMqttServerConnectionHandler
         if (connectionStatus.returnCode ==
             MqttConnectReturnCode.noneSpecified) {
           throw NoConnectionException('The maximum allowed connection attempts '
-              '({$MqttConnectionHandlerBase.maxConnectionAttempts}) were exceeded. '
+              '({$maxConnectionAttempts}) were exceeded. '
               'The broker is not responding to the connection request message '
               '(Missing Connection Acknowledgement?');
         } else {
           throw NoConnectionException('The maximum allowed connection attempts '
-              '({$MqttConnectionHandlerBase.maxConnectionAttempts}) were exceeded. '
+              '({$maxConnectionAttempts}) were exceeded. '
               'The broker is not responding to the connection request message correctly'
               'The return code is ${connectionStatus.returnCode}');
         }

--- a/lib/src/mqtt_browser_client.dart
+++ b/lib/src/mqtt_browser_client.dart
@@ -12,16 +12,26 @@ class MqttBrowserClient extends MqttClient {
   /// default Mqtt Port.
   /// The server hostname to connect to
   /// The client identifier to use to connect with
-  MqttBrowserClient(String server, String clientIdentifier)
-      : super(server, clientIdentifier);
+  MqttBrowserClient(
+    String server,
+    String clientIdentifier, {
+    this.maxConnectionAttempts = 3,
+  }) : super(server, clientIdentifier);
 
   /// Initializes a new instance of the MqttServerClient class using
   /// the supplied Mqtt Port.
   /// The server hostname to connect to
   /// The client identifier to use to connect with
   /// The port to use
-  MqttBrowserClient.withPort(String server, String clientIdentifier, int port)
-      : super.withPort(server, clientIdentifier, port);
+  MqttBrowserClient.withPort(
+    String server,
+    String clientIdentifier,
+    int port, {
+    this.maxConnectionAttempts = 3,
+  }) : super.withPort(server, clientIdentifier, port);
+
+  /// Max connection attempts
+  final int maxConnectionAttempts;
 
   /// Performs a connect to the message broker with an optional
   /// username and password for the purposes of authentication.
@@ -34,7 +44,10 @@ class MqttBrowserClient extends MqttClient {
       [String username, String password]) async {
     instantiationCorrect = true;
     clientEventBus = events.EventBus();
-    connectionHandler = SynchronousMqttBrowserConnectionHandler(clientEventBus);
+    connectionHandler = SynchronousMqttBrowserConnectionHandler(
+      clientEventBus,
+      maxConnectionAttempts: maxConnectionAttempts,
+    );
     return await super.connect(username, password);
   }
 }

--- a/lib/src/mqtt_server_client.dart
+++ b/lib/src/mqtt_server_client.dart
@@ -12,16 +12,23 @@ class MqttServerClient extends MqttClient {
   /// default Mqtt Port.
   /// The server hostname to connect to
   /// The client identifier to use to connect with
-  MqttServerClient(String server, String clientIdentifier)
-      : super(server, clientIdentifier);
+  MqttServerClient(
+    String server,
+    String clientIdentifier, {
+    this.maxConnectionAttempts = 3,
+  }) : super(server, clientIdentifier);
 
   /// Initializes a new instance of the MqttServerClient class using
   /// the supplied Mqtt Port.
   /// The server hostname to connect to
   /// The client identifier to use to connect with
   /// The port to use
-  MqttServerClient.withPort(String server, String clientIdentifier, int port)
-      : super.withPort(server, clientIdentifier, port);
+  MqttServerClient.withPort(
+    String server,
+    String clientIdentifier,
+    int port, {
+    this.maxConnectionAttempts = 3,
+  }) : super.withPort(server, clientIdentifier, port);
 
   /// The security context for secure usage
   SecurityContext securityContext = SecurityContext.defaultContext;
@@ -39,6 +46,9 @@ class MqttServerClient extends MqttClient {
   /// secure websockets(wss).
   bool secure = false;
 
+  /// Max connection attempts
+  final int maxConnectionAttempts;
+
   /// Performs a connect to the message broker with an optional
   /// username and password for the purposes of authentication.
   /// If a username and password are supplied these will override
@@ -50,7 +60,10 @@ class MqttServerClient extends MqttClient {
       [String username, String password]) async {
     instantiationCorrect = true;
     clientEventBus = events.EventBus();
-    connectionHandler = SynchronousMqttServerConnectionHandler(clientEventBus);
+    connectionHandler = SynchronousMqttServerConnectionHandler(
+      clientEventBus,
+      maxConnectionAttempts: 3,
+    );
     if (useWebSocket) {
       connectionHandler.secure = false;
       connectionHandler.useWebSocket = true;

--- a/test/mqtt_client_connection_secure_test.dart
+++ b/test/mqtt_client_connection_secure_test.dart
@@ -77,7 +77,10 @@ void main() {
   group('Synchronous MqttConnectionHandler', () {
     test('Connect to bad host name', () async {
       final clientEventBus = events.EventBus();
-      final ch = SynchronousMqttServerConnectionHandler(clientEventBus);
+      final ch = SynchronousMqttServerConnectionHandler(
+        clientEventBus,
+        maxConnectionAttempts: 3,
+      );
       ch.secure = true;
       try {
         await ch.connect(nonExistantHostName, mockBrokerPort,
@@ -95,7 +98,10 @@ void main() {
       }
 
       final clientEventBus = events.EventBus();
-      final ch = SynchronousMqttServerConnectionHandler(clientEventBus);
+      final ch = SynchronousMqttServerConnectionHandler(
+        clientEventBus,
+        maxConnectionAttempts: 3,
+      );
       ch.secure = true;
       ch.onDisconnected = disconnectCB;
       try {
@@ -144,7 +150,10 @@ void main() {
 
       await broker.start();
       final clientEventBus = events.EventBus();
-      final ch = SynchronousMqttServerConnectionHandler(clientEventBus);
+      final ch = SynchronousMqttServerConnectionHandler(
+        clientEventBus,
+        maxConnectionAttempts: 3,
+      );
       ch.secure = true;
       final context = SecurityContext.defaultContext;
       final currDir = path.current + path.separator;
@@ -179,7 +188,10 @@ void main() {
       broker.pemName = 'self_signed';
       await broker.start();
       final clientEventBus = events.EventBus();
-      final ch = SynchronousMqttServerConnectionHandler(clientEventBus);
+      final ch = SynchronousMqttServerConnectionHandler(
+        clientEventBus,
+        maxConnectionAttempts: 3,
+      );
       ch.secure = true;
       ch.onDisconnected = disconnectCB;
       final context = SecurityContext();
@@ -201,7 +213,10 @@ void main() {
       broker.pemName = 'self_signed';
       await broker.start();
       final clientEventBus = events.EventBus();
-      final ch = SynchronousMqttServerConnectionHandler(clientEventBus);
+      final ch = SynchronousMqttServerConnectionHandler(
+        clientEventBus,
+        maxConnectionAttempts: 3,
+      );
       ch.secure = true;
       // Skip bad certificate
       ch.onBadCertificate = (_) => true;

--- a/test/mqtt_client_connection_unsecure_test.dart
+++ b/test/mqtt_client_connection_unsecure_test.dart
@@ -76,7 +76,10 @@ void main() {
   group('Synchronous MqttConnectionHandler', () {
     test('Connect to bad host name', () async {
       final clientEventBus = events.EventBus();
-      final ch = SynchronousMqttServerConnectionHandler(clientEventBus);
+      final ch = SynchronousMqttServerConnectionHandler(
+        clientEventBus,
+        maxConnectionAttempts: 3,
+      );
       try {
         await ch.connect(nonExistantHostName, mockBrokerPort,
             MqttConnectMessage().withClientIdentifier(testClientId));
@@ -95,7 +98,10 @@ void main() {
       }
 
       final clientEventBus = events.EventBus();
-      final ch = SynchronousMqttServerConnectionHandler(clientEventBus);
+      final ch = SynchronousMqttServerConnectionHandler(
+        clientEventBus,
+        maxConnectionAttempts: 3,
+      );
       ch.onDisconnected = disconnectCB;
       try {
         await ch.connect(mockBrokerAddress, badPort,
@@ -111,7 +117,10 @@ void main() {
     test('Connect no connect ack', () async {
       await broker.start();
       final clientEventBus = events.EventBus();
-      final ch = SynchronousMqttServerConnectionHandler(clientEventBus);
+      final ch = SynchronousMqttServerConnectionHandler(
+        clientEventBus,
+        maxConnectionAttempts: 3,
+      );
       try {
         await ch.connect(mockBrokerAddress, mockBrokerPort,
             MqttConnectMessage().withClientIdentifier(testClientId));
@@ -135,7 +144,10 @@ void main() {
       }
 
       final clientEventBus = events.EventBus();
-      final ch = SynchronousMqttServerConnectionHandler(clientEventBus);
+      final ch = SynchronousMqttServerConnectionHandler(
+        clientEventBus,
+        maxConnectionAttempts: 3,
+      );
       broker.setMessageHandler = messageHandler;
       ch.onConnected = connectCb;
       await ch.connect(mockBrokerAddress, mockBrokerPort,
@@ -155,7 +167,10 @@ void main() {
       }
 
       final clientEventBus = events.EventBus();
-      final ch = SynchronousMqttServerConnectionHandler(clientEventBus);
+      final ch = SynchronousMqttServerConnectionHandler(
+        clientEventBus,
+        maxConnectionAttempts: 3,
+      );
       broker.setMessageHandler = messageHandler;
       final status = await ch.connect(mockBrokerAddress, mockBrokerPort,
           MqttConnectMessage().withClientIdentifier(testClientId));
@@ -191,7 +206,10 @@ void main() {
       }
 
       final clientEventBus = events.EventBus();
-      final ch = SynchronousMqttServerConnectionHandler(clientEventBus);
+      final ch = SynchronousMqttServerConnectionHandler(
+        clientEventBus,
+        maxConnectionAttempts: 3,
+      );
       broker.setMessageHandler = messageHandlerConnect;
       await ch.connect(mockBrokerAddress, mockBrokerPort,
           MqttConnectMessage().withClientIdentifier(testClientId));

--- a/test/mqtt_client_connection_ws_test.dart
+++ b/test/mqtt_client_connection_ws_test.dart
@@ -28,7 +28,10 @@ void main() {
     test('Invalid URL', () async {
       try {
         final clientEventBus = events.EventBus();
-        final ch = SynchronousMqttServerConnectionHandler(clientEventBus);
+        final ch = SynchronousMqttServerConnectionHandler(
+          clientEventBus,
+          maxConnectionAttempts: 3,
+        );
         ch.useWebSocket = true;
         await ch.connect(mockBrokerAddressWsBad, mockBrokerPortWs,
             MqttConnectMessage().withClientIdentifier(testClientId));
@@ -53,7 +56,10 @@ void main() {
     test('Invalid URL - bad scheme', () async {
       try {
         final clientEventBus = events.EventBus();
-        final ch = SynchronousMqttServerConnectionHandler(clientEventBus);
+        final ch = SynchronousMqttServerConnectionHandler(
+          clientEventBus,
+          maxConnectionAttempts: 3,
+        );
         ch.useWebSocket = true;
         await ch.connect(mockBrokerAddressWsNoScheme, mockBrokerPortWs,
             MqttConnectMessage().withClientIdentifier(testClientId));
@@ -90,7 +96,10 @@ void main() {
 
       await brokerWs.start();
       final clientEventBus = events.EventBus();
-      final ch = SynchronousMqttServerConnectionHandler(clientEventBus);
+      final ch = SynchronousMqttServerConnectionHandler(
+        clientEventBus,
+        maxConnectionAttempts: 3,
+      );
       MqttLogger.loggingOn = true;
       ch.useWebSocket = true;
       ch.websocketProtocols = <String>['SJHprotocol'];


### PR DESCRIPTION
### Issue
Currently the `maxConnectionAttempts` is always locked to `3`. In certain use cases this is too much. I need to have full control over the connection attempts, so I need a `maxConnectionAttempts` of `1`.

### Solution
Let the user customize the `maxConnectionAttempts` during client creation. This change should be backward compatible.