### PR TITLE
Change dynamic parameter to X509Certificate

### DIFF
--- a/lib/src/connectionhandling/mqtt_client_mqtt_connection_handler_base.dart
+++ b/lib/src/connectionhandling/mqtt_client_mqtt_connection_handler_base.dart
@@ -48,7 +48,7 @@ abstract class MqttConnectionHandlerBase implements IMqttConnectionHandler {
 
   /// Callback function to handle bad certificate. if true, ignore the error.
   @override
-  bool Function(dynamic certificate) onBadCertificate;
+  bool Function(X509Certificate certificate) onBadCertificate;
 
   /// Max connection attempts
   final int maxConnectionAttempts;


### PR DESCRIPTION
This fixes an error of casting dynamic value to X509Certificate