### PR TITLE
Switch to dynamic parameter from X509Certificate

### DIFF
--- a/lib/src/mqtt_server_client.dart
+++ b/lib/src/mqtt_server_client.dart
@@ -34,7 +34,7 @@ class MqttServerClient extends MqttClient {
   SecurityContext securityContext = SecurityContext.defaultContext;
 
   /// Callback function to handle bad certificate. if true, ignore the error.
-  bool Function(X509Certificate certificate) onBadCertificate;
+  bool Function(dynamic certificate) onBadCertificate;
 
   /// If set use a websocket connection, otherwise use the default TCP one
   bool useWebSocket = false;


### PR DESCRIPTION
This is required as the base handler class has a dynamic parameter which doesn't depend on X509Certificate class available in 'dart:io'