### PR TITLE
fix null safety

### DIFF
--- a/lib/src/messages/publish/mqtt_client_mqtt_publish_payload.dart
+++ b/lib/src/messages/publish/mqtt_client_mqtt_publish_payload.dart
@@ -66,7 +66,7 @@ class MqttPublishPayload extends MqttPayload {
   }
 
   /// Converts an array of bytes to a character string.
-  static String bytesToStringAsString(typed.Uint8Buffer message) {
+  static String bytesToStringAsString(typed.Uint8Buffer? message) {
     final sb = StringBuffer();
     message.forEach(sb.writeCharCode);
     return sb.toString();


### PR DESCRIPTION
1. Function bytesToStringAsString take argument with proper null safety.