### PR TITLE
Fix inconsistent typing in MqttClientTopicFilter

### DIFF
--- a/lib/src/management/mqtt_client_topic_filter.dart
+++ b/lib/src/management/mqtt_client_topic_filter.dart
@@ -20,7 +20,7 @@ class MqttClientTopicFilter {
     _subscriptionTopic = SubscriptionTopic(_topic);
     _clientUpdates!.listen(_topicIn);
     _updates =
-        StreamController<List<MqttReceivedMessage<MqttMessage>>>.broadcast(
+        StreamController<List<MqttReceivedMessage<MqttMessage?>>>.broadcast(
             sync: true);
   }
 


### PR DESCRIPTION
The type used in the constructor does not match the type of the member on line 36 and the return type of the getter on line 39.