### PR TITLE
Self-signed cert support for dart:io based Websocket connections

### DIFF
--- a/lib/src/mqtt_server_client.dart
+++ b/lib/src/mqtt_server_client.dart
@@ -72,6 +72,9 @@ class MqttServerClient extends MqttClient {
       connectionHandler.useWebSocket = true;
       connectionHandler.useAlternateWebSocketImplementation =
           useAlternateWebSocketImplementation;
+      if (connectionHandler.useAlternateWebSocketImplementation) {
+        connectionHandler.securityContext = securityContext;
+      }
       if (websocketProtocolString != null) {
         connectionHandler.websocketProtocols = websocketProtocolString;
       }


### PR DESCRIPTION
Your dart:io based alternate Websocket implementation can handle the user's custom secureContext object but that has not been passed to the MqttServerWs2Connection object.