### PR TITLE
Throw TypeError on nulls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 9.7.3
+Throw TypeError on nulls, as NullThrownError is deprecated in Dart 2.19.
+
 # 9.7.2
 Issue 410
 

--- a/lib/src/connectionhandling/browser/mqtt_client_mqtt_browser_ws_connection.dart
+++ b/lib/src/connectionhandling/browser/mqtt_client_mqtt_browser_ws_connection.dart
@@ -195,7 +195,7 @@ class MqttBrowserWsConnection extends MqttBrowserConnection<WebSocket> {
   List<StreamSubscription> onListen() {
     final webSocket = client;
     if (webSocket == null) {
-      throw NullThrownError();
+      throw TypeError();
     }
 
     return [

--- a/lib/src/connectionhandling/server/mqtt_client_mqtt_server_normal_connection.dart
+++ b/lib/src/connectionhandling/server/mqtt_client_mqtt_server_normal_connection.dart
@@ -121,7 +121,7 @@ class MqttServerNormalConnection extends MqttServerConnection<Socket> {
   StreamSubscription onListen() {
     final socket = client;
     if (socket == null) {
-      throw NullThrownError();
+      throw TypeError();
     }
 
     return socket.listen(onData, onError: onError, onDone: onDone);

--- a/lib/src/connectionhandling/server/mqtt_client_mqtt_server_secure_connection.dart
+++ b/lib/src/connectionhandling/server/mqtt_client_mqtt_server_secure_connection.dart
@@ -144,7 +144,7 @@ class MqttServerSecureConnection extends MqttServerConnection<SecureSocket> {
   StreamSubscription onListen() {
     final socket = client;
     if (socket == null) {
-      throw NullThrownError();
+      throw TypeError();
     }
 
     return socket.listen(onData, onError: onError, onDone: onDone);

--- a/lib/src/connectionhandling/server/mqtt_client_mqtt_server_ws_connection.dart
+++ b/lib/src/connectionhandling/server/mqtt_client_mqtt_server_ws_connection.dart
@@ -154,7 +154,7 @@ class MqttServerWsConnection extends MqttServerConnection<WebSocket> {
   StreamSubscription onListen() {
     final webSocket = client;
     if (webSocket == null) {
-      throw NullThrownError();
+      throw TypeError();
     }
 
     return webSocket.listen(onData, onError: onError, onDone: onDone);

--- a/lib/src/mqtt_client.dart
+++ b/lib/src/mqtt_client.dart
@@ -279,7 +279,7 @@ class MqttClient {
     // Do the connection
     final connectionHandler = this.connectionHandler;
     if (connectionHandler == null) {
-      throw NullThrownError();
+      throw TypeError();
     }
     if (websocketProtocolString != null) {
       connectionHandler.websocketProtocols = websocketProtocolString;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: mqtt_client
 description: A server and browser based MQTT client for Dart supporting normal, secure sockets and websockets.
-version: 9.7.2
+version: 9.7.3
 homepage: https://github.com/shamblett/mqtt_client
 
 funding:


### PR DESCRIPTION
Refactor to throw `TypeError` on nulls, rather than `NullThrownError`, which is deprecated in Dart 2.19:
https://api.dart.dev/beta/2.19.0-444.1.beta/dart-core/NullThrownError-class.html