### PR TITLE
fix(lib/mqtt_browser_client): switch dart:html to universal_html

### DIFF
--- a/lib/mqtt_browser_client.dart
+++ b/lib/mqtt_browser_client.dart
@@ -8,7 +8,7 @@
 library mqtt_browser_client;
 
 import 'dart:async';
-import 'dart:html';
+import 'package:universal_html/html.dart';
 import 'dart:typed_data';
 import 'package:event_bus/event_bus.dart' as events;
 import 'package:typed_data/typed_data.dart' as typed;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   typed_data: '^1.3.2'
   event_bus: '^2.0.0'
   path: '^1.8.2'
+  universal_html: '^2.2.4'
   crypto: '^3.0.3'
   meta: '^1.9.1'
 


### PR DESCRIPTION
Focus is to fix some issues when using with flutter. since the `dart:html` package only supports browsers, it is currently not possible to bundle both browser and APK support within the same application, changing this to a universal html package, should allow supporting multiple platforms within a single application.