### PR TITLE
Add support for custom WebSocket path

### DIFF
--- a/lib/src/connectionhandling/server/mqtt_client_mqtt_server_ws2_connection.dart
+++ b/lib/src/connectionhandling/server/mqtt_client_mqtt_server_ws2_connection.dart
@@ -108,7 +108,8 @@ class MqttServerWs2Connection extends MqttServerWsConnection {
     events.EventBus? eventBus,
     List<RawSocketOption> socketOptions,
     Duration? socketTimeout,
-  ) : super(eventBus, socketOptions, socketTimeout);
+    String? websocketPath,
+  ) : super(eventBus, socketOptions, socketTimeout, websocketPath);
 
   /// Initializes a new instance of the MqttWs2Connection class.
   MqttServerWs2Connection.fromConnect(
@@ -117,7 +118,7 @@ class MqttServerWs2Connection extends MqttServerWsConnection {
     events.EventBus eventBus,
     List<RawSocketOption> socketOptions,
     Duration? socketTimeout,
-  ) : super(eventBus, socketOptions, socketTimeout) {
+  ) : super(eventBus, socketOptions, socketTimeout, null) {
     connect(server, port);
   }
 
@@ -142,6 +143,11 @@ class MqttServerWs2Connection extends MqttServerWsConnection {
       throw NoConnectionException(message);
     }
     uri = uri.replace(port: port);
+
+    // Add custom path if specified, otherwise default to /
+    if (super.websocketPath != null && super.websocketPath!.isNotEmpty) {
+      uri = uri.replace(path: super.websocketPath);
+    }
 
     final uriString = uri.toString();
     MqttLogger.log(
@@ -221,6 +227,11 @@ class MqttServerWs2Connection extends MqttServerWsConnection {
       throw NoConnectionException(message);
     }
     uri = uri.replace(port: port);
+
+    // Add custom path if specified, otherwise default to /
+    if (super.websocketPath != null && super.websocketPath!.isNotEmpty) {
+      uri = uri.replace(path: super.websocketPath);
+    }
 
     final uriString = uri.toString();
     MqttLogger.log(

--- a/lib/src/connectionhandling/server/mqtt_client_mqtt_server_ws_connection.dart
+++ b/lib/src/connectionhandling/server/mqtt_client_mqtt_server_ws_connection.dart
@@ -19,11 +19,15 @@ class MqttServerWsConnection extends MqttServerConnection<WebSocket> {
   /// User defined websocket headers
   Map<String, dynamic>? headers;
 
+  /// User-defined websocket path.
+  String? websocketPath;
+
   /// Default constructor
   MqttServerWsConnection(
     super.eventBus,
     super.socketOptions,
     super.socketTimeout,
+    this.websocketPath,
   );
 
   /// Initializes a new instance of the MqttConnection class.
@@ -60,6 +64,11 @@ class MqttServerWsConnection extends MqttServerConnection<WebSocket> {
     }
 
     uri = uri.replace(port: port);
+
+    // Add custom path if specified, otherwise default to /
+    if (websocketPath != null && websocketPath!.isNotEmpty) {
+      uri = uri.replace(path: websocketPath);
+    }
 
     final uriString = uri.toString();
     MqttLogger.log(
@@ -123,6 +132,11 @@ class MqttServerWsConnection extends MqttServerConnection<WebSocket> {
     }
 
     uri = uri.replace(port: port);
+
+    // Add custom path if specified, otherwise default to /
+    if (websocketPath != null && websocketPath!.isNotEmpty) {
+      uri = uri.replace(path: websocketPath);
+    }
 
     final uriString = uri.toString();
     MqttLogger.log(

--- a/lib/src/connectionhandling/server/mqtt_client_synchronous_mqtt_server_connection_handler.dart
+++ b/lib/src/connectionhandling/server/mqtt_client_synchronous_mqtt_server_connection_handler.dart
@@ -18,10 +18,14 @@ class SynchronousMqttServerConnectionHandler
     required super.socketOptions,
     required super.socketTimeout,
     reconnectTimePeriod = 5000,
+    this.websocketPath,
   }) : super(maxConnectionAttempts: maxConnectionAttempts) {
     connectTimer = MqttCancellableAsyncSleep(reconnectTimePeriod);
     initialiseListeners();
   }
+
+  /// User-defined websocket path.
+  String? websocketPath;
 
   /// Synchronously connect to the specific Mqtt Connection.
   @override
@@ -56,6 +60,7 @@ class SynchronousMqttServerConnectionHandler
               clientEventBus,
               socketOptions,
               socketTimeout,
+              websocketPath,
             );
           } else {
             MqttLogger.log(
@@ -66,6 +71,7 @@ class SynchronousMqttServerConnectionHandler
               clientEventBus,
               socketOptions,
               socketTimeout,
+              websocketPath,
             );
           }
 

--- a/lib/src/mqtt_server_client.dart
+++ b/lib/src/mqtt_server_client.dart
@@ -56,6 +56,9 @@ class MqttServerClient extends MqttClient {
     }
   }
 
+  /// User-defined websocket path.
+  String? websocketPath;
+
   /// Initializes a new instance of the MqttServerClient class using the
   /// default Mqtt Port.
   /// The server hostname or URL to connect to
@@ -111,6 +114,7 @@ class MqttServerClient extends MqttClient {
     if (useWebSocket) {
       connectionHandler.secure = false;
       connectionHandler.useWebSocket = true;
+      connectionHandler.websocketPath = websocketPath;
       connectionHandler.useAlternateWebSocketImplementation =
           useAlternateWebSocketImplementation;
       if (connectionHandler.useAlternateWebSocketImplementation) {


### PR DESCRIPTION
Add support for custom WebSocket path via optional websocketPath property.
Allows connecting to brokers that serve MQTT over WebSocket on non-root paths (e.g., /mqtt).
Tested with wss://