### PR TITLE
Refactor client event bus checks to use a dedicated method

### DIFF
--- a/lib/src/connectionhandling/browser/mqtt_client_mqtt_browser_connection.dart
+++ b/lib/src/connectionhandling/browser/mqtt_client_mqtt_browser_connection.dart
@@ -70,7 +70,7 @@ abstract class MqttBrowserConnection<T extends Object>
           'MqttBrowserConnection::_onData - message received ',
           msg,
         );
-        if (!clientEventBus!.streamController.isClosed) {
+        if (!_isClientEventBusClosed) {
           if (msg!.header!.messageType == MqttMessageType.connectAck) {
             clientEventBus!.fire(ConnectAckMessageAvailable(msg));
           } else {
@@ -87,6 +87,9 @@ abstract class MqttBrowserConnection<T extends Object>
       }
     }
   }
+
+  /// Checks if the client event bus is closed.
+  bool get _isClientEventBusClosed => (clientEventBus?.streamController.isClosed ?? true);
 
   /// Create the listening stream subscription and subscribe the callbacks
   void _startListening() {

--- a/lib/src/connectionhandling/server/mqtt_client_mqtt_server_connection.dart
+++ b/lib/src/connectionhandling/server/mqtt_client_mqtt_server_connection.dart
@@ -76,7 +76,7 @@ abstract class MqttServerConnection<T extends Object>
           'MqttServerConnection::_onData - message received ',
           msg,
         );
-        if (!clientEventBus!.streamController.isClosed) {
+        if (!_isClientEventBusClosed) {
           if (msg!.header!.messageType == MqttMessageType.connectAck) {
             clientEventBus!.fire(ConnectAckMessageAvailable(msg));
           } else {
@@ -93,6 +93,9 @@ abstract class MqttServerConnection<T extends Object>
       }
     }
   }
+
+  /// Checks if the client event bus is closed.
+  bool get _isClientEventBusClosed => (clientEventBus?.streamController.isClosed ?? true);
 
   // Apply any socket options, true indicates options applied
   bool _applySocketOptions(Socket socket, List<RawSocketOption> socketOptions) {


### PR DESCRIPTION
Hello, it was observed that issue #620 also occurs in the else block of this section. The same errors were encountered on our side as well, so null checks were added before all locations where clientEventBus was being force-unwrapped throughout the package. A review of these changes would be appreciated.