### PR TITLE
Clear subscriptions and pending subscriptions when not resubscribing on auto reconnect

### DIFF
--- a/lib/src/mqtt_client_subscriptions_manager.dart
+++ b/lib/src/mqtt_client_subscriptions_manager.dart
@@ -479,6 +479,8 @@ class SubscriptionsManager {
         }
       }
     } else {
+      subscriptions.clear();
+      pendingSubscriptions.clear();
       MqttLogger.log(
         'Subscriptionsmanager::_resubscribe - '
         'NOT resubscribing from auto reconnect ${resubscribeEvent.fromAutoReconnect}, resubscribeOnAutoReconnect is false',


### PR DESCRIPTION
### Problem

When `resubscribeOnAutoReconnect` is set to **false**, and the app tries to subscribe again (from outside the package) to the same topic(s) after an auto-reconnect, the `subscriptions` and `pendingSubscriptions` lists are not cleared. As a result, `registerSubscription()` returns the old, no-longer-active subscription, and a new subscription cannot be created—so the subscribe attempt effectively fails.

### Root cause

During auto-reconnect, when resubscribe is disabled (`resubscribeOnAutoReconnect=false`), the internal subscription state is not reset. A subsequent subscribe call for the same topic ends up reusing a stale/invalid subscription entry.

### Fix

When `resubscribeOnAutoReconnect` is **false**, `subscriptions` and `pendingSubscriptions` are cleared during the auto-reconnect flow. This allows new subscriptions to be created successfully after reconnect, even for the same topic(s).

### Notes

This change only affects the `resubscribeOnAutoReconnect=false` scenario; behavior remains unchanged when the flag is `true`.
