### PR TITLE
fix: Omit default port from Host header in MqttServerWs2Connection

### DIFF
--- a/lib/src/connectionhandling/server/mqtt_client_mqtt_server_ws2_connection.dart
+++ b/lib/src/connectionhandling/server/mqtt_client_mqtt_server_ws2_connection.dart
@@ -278,7 +278,9 @@ class MqttServerWs2Connection extends MqttServerWsConnection {
     final c = Completer<bool>();
     const endL = '\r\n';
     final path = '${uri.path}?${uri.query}';
-    final host = '${uri.host}:${uri.port.toString()}';
+    final isDefaultPort = (uri.scheme == 'wss' && uri.port == 443) ||
+        (uri.scheme == 'ws' && uri.port == 80);
+    final host = isDefaultPort ? uri.host : '${uri.host}:${uri.port}';
     final now = DateTime.now().millisecondsSinceEpoch;
     final key = 'mqtt-$now';
     final key64 = base64.encode(utf8.encode(key));


### PR DESCRIPTION
## Summary

The `_performWSHandshake` method in `MqttServerWs2Connection` always includes the port number in the `Host` header, even when using the default port for the scheme (443 for `wss://`, 80 for `ws://`).

Per [RFC 7230 Section 5.4](https://datatracker.ietf.org/doc/html/rfc7230#section-5.4):
> If the target URI includes an authority component, then a client MUST send a field-value for Host that is identical to that authority component, excluding any userinfo subcomponent and its "@" delimiter.

And [RFC 3986 Section 3.2.3](https://datatracker.ietf.org/doc/html/rfc3986#section-3.2.3):
> URI producers and normalizers should omit the port component and its ":" delimiter if port is empty or if its value would be the same as that of the scheme's default.

**Current behavior:** `Host: endpoint:443` (always includes port)
**Expected behavior:** `Host: endpoint` (omit default port)

## Problem

AWS IoT Core (and potentially other WebSocket servers that perform SigV4 or similar Host-header-based authentication) rejects WebSocket upgrade requests with `Host: endpoint:443`, returning `403 Forbidden`. This is because the server normalizes the Host header by stripping the default port, causing a mismatch with the signed request.

The standard `MqttServerWsConnection` does not have this issue because Dart's `WebSocket.connect()` / `HttpClient` correctly omits the default port from the Host header.

## Fix

Only include the port in the Host header when it differs from the scheme's default port:
- `wss://` → default port 443
- `ws://` → default port 80