### PR TITLE
Issue 644

### DIFF
--- a/lib/src/connectionhandling/server/mqtt_client_mqtt_server_normal_connection.dart
+++ b/lib/src/connectionhandling/server/mqtt_client_mqtt_server_normal_connection.dart
@@ -94,6 +94,8 @@ class MqttServerNormalConnection extends MqttServerConnection<Socket> {
               );
             }
             client = socket;
+            readWrapper = ReadWrapper();
+            messageStream = MqttByteBuffer(typed.Uint8Buffer());
             _startListening();
             completer.complete();
           })

--- a/lib/src/connectionhandling/server/mqtt_client_mqtt_server_secure_connection.dart
+++ b/lib/src/connectionhandling/server/mqtt_client_mqtt_server_secure_connection.dart
@@ -122,6 +122,8 @@ class MqttServerSecureConnection extends MqttServerConnection<SecureSocket> {
               );
             }
             client = socket;
+            readWrapper = ReadWrapper();
+            messageStream = MqttByteBuffer(typed.Uint8Buffer());
             MqttLogger.log(
               'MqttSecureConnection::connectAuto - start listening',
             );

--- a/lib/src/connectionhandling/server/mqtt_client_mqtt_server_ws2_connection.dart
+++ b/lib/src/connectionhandling/server/mqtt_client_mqtt_server_ws2_connection.dart
@@ -241,6 +241,8 @@ class MqttServerWs2Connection extends MqttServerWsConnection {
                 ),
                 serverSide: false,
               );
+              readWrapper = ReadWrapper();
+              messageStream = MqttByteBuffer(typed.Uint8Buffer());
               MqttLogger.log(
                 'MqttWs2Connection::connectAuto - start listening',
               );

--- a/lib/src/connectionhandling/server/mqtt_client_mqtt_server_ws_connection.dart
+++ b/lib/src/connectionhandling/server/mqtt_client_mqtt_server_ws_connection.dart
@@ -137,6 +137,8 @@ class MqttServerWsConnection extends MqttServerConnection<WebSocket> {
           )
           .then((socket) {
             client = socket;
+            readWrapper = ReadWrapper();
+            messageStream = MqttByteBuffer(typed.Uint8Buffer());
             _startListening();
             completer.complete();
           })


### PR DESCRIPTION
Based on my analysis of the codebase and the error provided in the GitHub issue, I have identified exactly under what conditions this LateInitializationError is triggered.

  The Trigger Condition
  This error occurs when the initial connection attempt fails, and then an auto-reconnect is subsequently triggered (either manually via doAutoReconnect() or automatically if configured to
  try again).

  This explains why the issue isn't seen in the examples or unit tests: those tests invariably ensure the initial connection succeeds before testing the disconnect/reconnect logic.

  Why it Happens
   1. Missing Initialization on Failure: When a user calls client.connect(), the underlying connection class (e.g., MqttServerNormalConnection) attempts to establish a socket. If this succeeds, it initializes the messageStream and readWrapper variables before listening to the stream. However, if the initial socket connection fails (e.g., broker is down, network timeout), the catchError block is triggered, and these fields are never initialized.
   2. Re-using the Connection Object: When a reconnection is triggered (like when the user calls doAutoReconnect(...)), the connection handler purposely reuses the existing connection object because autoReconnectInProgress is true. It then calls the connectAuto() method instead of connect().
   3. The Oversight in connectAuto: In all connection classes (e.g., MqttServerNormalConnection, MqttServerSecureConnection, MqttBrowserWsConnection, etc.), the connectAuto() method successfully establishes the new socket and starts listening (_startListening()), but it completely omits the initialization of messageStream and readWrapper.
   4. The Crash: Because the initial connect() failed to initialize them, and connectAuto() didn't initialize them either, they remain uninitialized. As soon as the newly connected broker sends its first byte of data, onData is fired, attempts to call messageStream.addAll(data), and throws the LateInitializationError.

  How to Fix It
  To fix this bug, we need to ensure messageStream and readWrapper are initialized in the .then() blocks of the connectAuto() methods across all connection implementation classes, just as
  they are in the regular connect() methods.